### PR TITLE
feat: make the json parse optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This GitHub Action retrieves one or more AWS Systems Manager Parameters from a g
     get-children: true           # optional, default false
     decryption: true             # optional, default false
     mask-values: true            # optional, default false
+    expand-json: true            # optional, default false
     prefix: SSM_                 # optional, allows any string value
 ```
 
@@ -33,7 +34,7 @@ AWS Systems Manager Parameter Store path to the parameter.
 (e.g. `ssm-path: /path/to/parameter`)
 
 #### `get-children` (optional)
-Boolean wich imposes to get parameters by path, retrieving all children values. Defaults to false.  
+Boolean which imposes to get parameters by path, retrieving all children values. Defaults to false.  
 (e.g. `get-children: true`)
 
 #### `decryption` (optional)
@@ -50,6 +51,10 @@ Boolean which indicates if extracted values should be masked in GitHub action lo
 #### `prefix` (optional)
 Add prefix in front of environment variable names to be set.
 (e.g. `prefix: TF_VAR_` will export `TF_VAR_ENV_VAR="value"`)
+
+#### `expand-json` (optional)
+Boolean which indicates whether JSON object parameters should be processed by field. Defaults to false.
+(e.g. `decryption: true`)  
 
 ---
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   mask-values:
     description: 'Indicates if extracted values should be masked in GitHub action logs'
     required: false
+  expand-json:
+    description: 'Indicates if extracted values should be expanded as JSON objects'
+    required: false
 runs:
   using: 'node20'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -11,12 +11,14 @@ async function run_action()
         const region = process.env.AWS_DEFAULT_REGION;
         const decryption = core.getInput('decryption') === 'true';
         const maskValues = core.getInput('mask-values') === 'true';
+        const expandJson = core.getInput('expand-json') === 'true';
 
         const params = await ssm.getParameters(ssmPath, getChildren, decryption, region);
+        
         for (let param of params)
         {
             const parsedValue = parseValue(param.Value);
-            if (typeof(parsedValue) === 'object') // Assume JSON object
+            if (typeof(parsedValue) === 'object' && expandJson) // Assume JSON object
             {
                 core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);
                 // Assume basic JSON structure


### PR DESCRIPTION
Because whenever we use JSON environment fields in AWS SSM, we actually need it as it is, this proposed change is making the splitting of the JSON optional and by default, disabled.